### PR TITLE
remove Unicode from email, support https links

### DIFF
--- a/resume.py
+++ b/resume.py
@@ -93,6 +93,7 @@ def tex(lines, contact_lines, *args):
     def replace_links(line):
         line = re.sub(r"<([^:]+@[^:]+?)>", r"\href{mailto:\1}{\1}", line)
         line = re.sub(r"<(http.+?)>", r"\url{\1}", line)
+        line = re.sub(r"<(https.+?)>", r"\url{\1}", line)
         return re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\href{\2}{\1}", line)
 
     contact_lines = "\n\n".join(map(replace_links, contact_lines))
@@ -131,7 +132,7 @@ def html(lines, contact_lines, *args):
     for line in contact_lines:
         if '@' in line and '--no-gravatar' not in args:
             gravatar = GRAVATAR.format(
-                hash=hashlib.md5(line.lower().strip('<>')).hexdigest())
+                hash=hashlib.md5(line.lower().strip('<>').encode('utf-8')).hexdigest())
             break
     if gravatar is not None:
         contact_lines.insert(0, "<img src='{}' />".format(gravatar))


### PR DESCRIPTION
I did not have the Unicode issues described by mofosyne, except when attempting to include the Gravatar:
  File "resume.py", line 135, in html
    hash=hashlib.md5(line.lower().strip('<>')).hexdigest())
TypeError: Unicode-objects must be encoded before hashing

This was resolved by encoding the string before passing it to hashlib.md5()

Also added https to replace_links()