### PR TITLE
Offer Vagrant for improved portability.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.log
+.vagrant

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pandoc-templates"]
 	path = pandoc-templates
-	url = git@github.com:jgm/pandoc-templates.git
+	url = https://github.com/jgm/pandoc-templates.git

--- a/README.markdown
+++ b/README.markdown
@@ -18,6 +18,12 @@ The Markdown flavor supported is
 sudo apt-get install texlive texlive-latex-extra tex-gyre lmodern
 ```
 
+To instead make use of the Vagrant box (assuming [the necessary prerequisites](https://www.vagrantup.com/docs/getting-started/)), just run:
+
+```
+vagrant up
+```
+
 ## Usage
 
 Clone the repo and create a new branch with a different Markdown file for your
@@ -26,6 +32,10 @@ resumé.
 To generate PDF and HTML versions of each .md file in the directory:
 
     $ make
+
+Or within the Vagrant box:
+
+    $ vagrant ssh -c "cd /vagrant && make"
 
 In order to enable visually appealing display of contact information, the
 Markdown is passed through a Python script that looks for contact details
@@ -37,6 +47,10 @@ By default, an image of your [Gravatar](http://www.gravatar.com) will be added
 to the HTML resumé.  To avoid this:
 
     $ GRAVATAR_OPTION=--no-gravatar make
+
+Or within the Vagrant box:
+
+    $ vagrant ssh -c "cd /vagrant && GRAVATAR_OPTION=--no-gravatar make"
 
 ## Unicode characters
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y git texlive texlive-latex-extra tex-gyre lmodern pandoc
+  SHELL
+end


### PR DESCRIPTION
Vagrant offers portability by containing all dependencies within a disposable VM. This PR provides the necessary Vagrant configuration and documentation for such use.

For those familiar with the Vagrant paradigm, getting up and running from a freshly-cloned repo consists of:

```
vagrant up
vagrant ssh -c "cd /vagrant && make"
```

Note: In order to enable anonymous retrieval of the Pandoc submodule, I had to change the submodule URL to HTTPS instead of SSH. This is made necessary by GitHub, not git in general. If you are using a pre-existing workspace, you may have to also update the remote URL manually in your `.git/config` to take advantage of Vagrant:

```
[submodule "pandoc-templates"]
	url = https://github.com/jgm/pandoc-templates.git
```