### PR TITLE
Add `--verify-repo=all` to the recommended tlmgr commands

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,9 +25,9 @@ The Markdown flavor supported is
     If you run into problems while running `make`, you might need to run the following
     commands first:
 
-        sudo tlmgr update --self
+        sudo tlmgr --verify-repo=all update --self
 
-        sudo tlmgr install tex-gyre titlesec
+        sudo tlmgr --verify-repo=all install tex-gyre titlesec
 
 ## Usage
 


### PR DESCRIPTION
As seen in tlmgr manual, without this option it's possible to run unverified code (because tlmgr downloads packages without using TLS)

> CRYPTOGRAPHIC VERIFICATION
    "tlmgr" and "install-tl" perform cryptographic verification if
    possible.  If verification is performed and successful, the programs
    report "(verified)" after loading the TLPDB; otherwise, they report
    "(not verified)".  **But either way, by default the installation and/or
    updates proceed normally**.
    If a program named "gpg" is available (that is, found in "PATH"), by
    default cryptographic signatures will be checked: we require the main
    repository be signed, but not any additional repositories. **If "gpg" is
    not available, by default signatures are not checked and no
    verification is carried out, but "tlmgr" still proceeds normally**.
    The behavior of the verification can be controlled by the command line
    and config file option "verify-repo" which takes one of the following
    values: "none", "main", or "all". With "none", no verification
    whatsoever is attempted.  **With "main" (the default) verification is
    required only for the main repository, and only if "gpg" is available**;
    though attempted for all, missing signatures of subsidiary repositories
    will not result in an error.  Finally, in the case of "all", "gpg" must
    be available and all repositories need to be signed.

It seems, unless this option is used, users are exposed to running unverified code.