### PR TITLE
fix backticks in re

### DIFF
--- a/resume.py
+++ b/resume.py
@@ -91,10 +91,10 @@ def tex(lines, contact_lines, *args):
     # just going to hardcode the two most common link formats for now so people
     # can put links in their contact info
     def replace_links(line):
-        line = re.sub(r"<([^:]+@[^:]+?)>", r"\href{mailto:\1}{\1}", line)
-        line = re.sub(r"<(http.+?)>", r"\url{\1}", line)
-        line = re.sub(r"<(https.+?)>", r"\url{\1}", line)
-        return re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\href{\2}{\1}", line)
+        line = re.sub(r"<([^:]+@[^:]+?)>", r"\\href{mailto:\1}{\1}", line)
+        line = re.sub(r"<(http.+?)>", r"\\url{\1}", line)
+        line = re.sub(r"<(https.+?)>", r"\\url{\1}", line)
+        return re.sub(r"\[([^\]]+)\]\(([^\)]+)\)", r"\\href{\2}{\1}", line)
 
     contact_lines = "\n\n".join(map(replace_links, contact_lines))
 


### PR DESCRIPTION
running in python 3.8 i'm getting the following error

```py
Traceback (most recent call last):
  File "/usr/lib/python3.8/sre_parse.py", line 1039, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\h'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "resume.py", line 173, in <module>
    main()
  File "resume.py", line 170, in main
    print(processor.process(format, lines, contact_lines, *sys.argv[1:]))
  File "resume.py", line 63, in process
    return handler(lines, contact_lines, *args)
  File "resume.py", line 99, in tex
    contact_lines = "\n\n".join(map(replace_links, contact_lines))
  File "resume.py", line 94, in replace_links
    line = re.sub(r"<([^:]+@[^:]+?)>", r"\href{mailto:\1}{\1}", line)
  File "/usr/lib/python3.8/re.py", line 208, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/lib/python3.8/re.py", line 325, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/lib/python3.8/re.py", line 316, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/lib/python3.8/sre_parse.py", line 1042, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \h at position 0
```

escaping the `\` fixes it